### PR TITLE
Revert to patternfly 3.59.5 to fix 404 on stylesheet from CDN

### DIFF
--- a/src/main/resources/META-INF/resources/chat-assistant.html
+++ b/src/main/resources/META-INF/resources/chat-assistant.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Quarkus Langchain4j Chat!</title>
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/5.3.2/css/patternfly.min.css">
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/5.3.2/css/patternfly-additions.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.59.5/css/patternfly.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.59.5/css/patternfly-additions.min.css">
 
     <style>
         #chat {


### PR DESCRIPTION
My chat assistant is unexpectedly ugly:

<img width="686" alt="image" src="https://github.com/user-attachments/assets/b1e4d658-df02-4a3e-9296-418c85761e06">

The cause is being unable to load the patternfly stylesheets. Checking https://cdnjs.com/libraries/patternfly, 3.x is the most recent version of patternfly available by cdn. I assume 5.x was available and was removed? I'm not sure whether the right fix is to downgrade patternfly to that version or to ship the css file locally, but I've gone for the downgrade. 

With that I get the expected attractive UI: 

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/a636c185-46cf-4716-83ae-15f5d1a290ef">
